### PR TITLE
Add support for picking up proxy info from standard env vars.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /pom.xml
 /deps.exe
 /.cpcache
+/.clj-kondo/.cache

--- a/README.md
+++ b/README.md
@@ -148,14 +148,18 @@ from [this](https://download.clojure.org/install/clojure-tools-1.10.1.492.zip)
 location. You can override the location of the jar with the `CLOJURE_TOOLS_CP`
 environment variable.
 
-## Non-standard options
+## Extra features
 
-The `deps.clj` script adds the following non-standard options:
+The `deps.clj` script adds the following features compared to the `clojure`
+tool:
 
 ```
  -Sdeps-file    Use this file instead of deps.edn
  -Scommand      A custom command that will be invoked. Substitutions: {{classpath}}, {{main-opts}}.
 ```
+
+It also is able to pick up [proxy information from environment
+variables](#proxy-environment-variables).
 
 ### -Scommand
 
@@ -214,6 +218,10 @@ $ lm -Sdeps '{:deps {medley {:mvn/version "1.2.0"}}}' -K \
 ### -Sdeps-file
 
 The  `-Sdeps-file` option may be used to load a different project file than `deps.edn`.
+
+### Proxy environment variables
+
+TODO
 
 ## License
 

--- a/deps.clj
+++ b/deps.clj
@@ -11,7 +11,7 @@
 (set! *warn-on-reflection* true)
 
 (def version "1.10.1.496")
-(def deps-clj-version "0.0.6")
+(def deps-clj-version "0.0.7-SNAPSHOT")
 
 (defn shell-command
   "Executes shell command.
@@ -216,6 +216,47 @@ function Get-StringHash($str) {
     (unzip dest (.getPath deps-clj-config-dir))
     (.delete dest)))
 
+(def ^:private authenticated-proxy-re #".+:.+@(.+):(\d+).*")
+(def ^:private unauthenticated-proxy-re #"(.+):(\d+).*")
+
+(defn parse-proxy-info
+  [s]
+  (when s
+    (let [p (cond
+              (clojure.string/starts-with? s "http://") (subs s 7)
+              (clojure.string/starts-with? s "https://") (subs s 8)
+              :else s)
+          auth-proxy-match (re-matches authenticated-proxy-re p)
+          unauth-proxy-match (re-matches unauthenticated-proxy-re p)
+          match->proxy-info (fn [m]
+                              {:host (nth m 1)
+                               :port (nth m 2)})]
+      (cond
+        auth-proxy-match
+        (binding [*out* *err*]
+          (println "WARNING: Proxy info is of authenticated type - discarding the user/pw as we do not support it!")
+          (match->proxy-info auth-proxy-match))
+
+        unauth-proxy-match
+        (match->proxy-info unauth-proxy-match)
+
+        :else
+        (binding [*out* *err*]
+          (println "WARNING: Can't parse proxy info - found:" s "- proceeding without using proxy!")
+          nil)))))
+
+(defn jvm-proxy-settings
+  []
+  (let [http-proxy  (parse-proxy-info (or (System/getenv "http_proxy")
+                                          (System/getenv "HTTP_PROXY")))
+        https-proxy (parse-proxy-info (or (System/getenv "https_proxy")
+                                          (System/getenv "HTTPS_PROXY")))]
+    (cond-> []
+      http-proxy (concat [(format "-Dhttp.proxyHost=%s" (:host http-proxy))
+                          (format "-Dhttp.proxyPort=%s" (:port http-proxy))])
+      https-proxy (concat [(format "-Dhttps.proxyHost=%s" (:host https-proxy))
+                           (format "-Dhttps.proxyPort=%s" (:port https-proxy))]))))
+
 (defn -main [& command-line-args]
   (let [windows? (windows?)
         args (loop [command-line-args (seq command-line-args)
@@ -283,13 +324,17 @@ function Get-StringHash($str) {
            downloaded-jar))
         deps-edn
         (or (:deps-file args)
-            "deps.edn")]
+            "deps.edn")
+        clj-main-cmd
+        (vec (concat [java-cmd]
+                     (jvm-proxy-settings)
+                     ["-Xms256m" "-classpath" tools-cp "clojure.main"]))]
     (when (:resolve-tags args)
       (let [f (io/file deps-edn)]
         (if (.exists f)
-          (do (shell-command [java-cmd "-Xms256m" "-classpath" tools-cp
-                              "clojure.main" "-m" "clojure.tools.deps.alpha.script.resolve-tags"
-                              (str "--deps-file=" deps-edn)])
+          (do (shell-command (into clj-main-cmd
+                                   ["-m" "clojure.tools.deps.alpha.script.resolve-tags"
+                                    (str "--deps-file=" deps-edn)]))
               (System/exit 0))
           (binding [*out* *err*]
             (println deps-edn "does not exist")
@@ -392,27 +437,26 @@ function Get-StringHash($str) {
             _ (when (and stale (not (:describe args)))
                 (when (:verbose args)
                   (println "Refreshing classpath"))
-                (shell-command (into [java-cmd "-Xms256m"
-                                      "-classpath" tools-cp
-                                      "clojure.main" "-m" "clojure.tools.deps.alpha.script.make-classpath2"
-                                      "--config-user" config-user
-                                      "--config-project" config-project
-                                      "--libs-file" (double-quote libs-file)
-                                      "--cp-file" (double-quote cp-file)
-                                      "--jvm-file" (double-quote jvm-file)
-                                      "--main-file" (double-quote main-file)]
-                                     tools-args)))
+                (shell-command (into clj-main-cmd
+                                     (concat
+                                      ["-m" "clojure.tools.deps.alpha.script.make-classpath2"
+                                       "--config-user" config-user
+                                       "--config-project" config-project
+                                       "--libs-file" (double-quote libs-file)
+                                       "--cp-file" (double-quote cp-file)
+                                       "--jvm-file" (double-quote jvm-file)
+                                       "--main-file" (double-quote main-file)]
+                                      tools-args))))
             cp
             (cond (:describe args) nil
                   (not (str/blank? (:force-cp args))) (:force-cp args)
                   :else (slurp (io/file cp-file)))]
         (cond (:pom args)
-              (shell-command [java-cmd "-Xms256m"
-                              "-classpath" tools-cp
-                              "clojure.main" "-m" "clojure.tools.deps.alpha.script.generate-manifest2"
-                              "--config-user" config-user
-                              "--config-project" config-project
-                              "--gen=pom" (str/join " " tools-args)])
+              (shell-command (into clj-main-cmd
+                                   ["-m" "clojure.tools.deps.alpha.script.generate-manifest2"
+                                    "--config-user" config-user
+                                    "--config-project" config-project
+                                    "--gen=pom" (str/join " " tools-args)]))
               (:print-classpath args)
               (println cp)
               (:describe args)
@@ -431,10 +475,9 @@ function Get-StringHash($str) {
                          [:main-aliases (str (:main-aliases args))]
                          [:all-aliases (str (:all-aliases args))]])
               (:tree args)
-              (println (str/trim (shell-command [java-cmd "-Xms256m"
-                                                 "-classpath" tools-cp
-                                                 "clojure.main" "-m" "clojure.tools.deps.alpha.script.print-tree"
-                                                 "--libs-file" libs-file]
+              (println (str/trim (shell-command (into clj-main-cmd
+                                                      ["-m" "clojure.tools.deps.alpha.script.print-tree"
+                                                       "--libs-file" libs-file])
                                                 {:to-string? true})))
               (:trace args)
               (println "Writing trace.edn")
@@ -452,8 +495,14 @@ function Get-StringHash($str) {
                     main-cache-opts (when (.exists (io/file main-file))
                                       (slurp main-file))
                     main-cache-opts (when main-cache-opts (str/split main-cache-opts #"\s"))
-                    main-args (into (vector java-cmd jvm-cache-opts (:jvm-opts args)
-                                            (str "-Dclojure.libfile=" libs-file) "-classpath" cp "clojure.main") main-cache-opts)
+                    main-args (concat [java-cmd]
+                                      (jvm-proxy-settings)
+                                      [jvm-cache-opts
+                                       (:jvm-opts args)
+                                       (str "-Dclojure.libfile=" libs-file)
+                                       "-classpath" cp
+                                       "clojure.main"]
+                                      main-cache-opts)
                     main-args (filterv some? main-args)
                     main-args (into main-args (:args args))]
                 (shell-command main-args)))))))

--- a/src/borkdude/deps.clj
+++ b/src/borkdude/deps.clj
@@ -216,6 +216,47 @@ function Get-StringHash($str) {
     (unzip dest (.getPath deps-clj-config-dir))
     (.delete dest)))
 
+(def ^:private authenticated-proxy-re #".+:.+@(.+):(\d+).*")
+(def ^:private unauthenticated-proxy-re #"(.+):(\d+).*")
+
+(defn parse-proxy-info
+  [s]
+  (when s
+    (let [p (cond
+              (clojure.string/starts-with? s "http://") (subs s 7)
+              (clojure.string/starts-with? s "https://") (subs s 8)
+              :else s)
+          auth-proxy-match (re-matches authenticated-proxy-re p)
+          unauth-proxy-match (re-matches unauthenticated-proxy-re p)
+          match->proxy-info (fn [m]
+                              {:host (nth m 1)
+                               :port (nth m 2)})]
+      (cond
+        auth-proxy-match
+        (binding [*out* *err*]
+          (println "WARNING: Proxy info is of authenticated type - discarding the user/pw as we do not support it!")
+          (match->proxy-info auth-proxy-match))
+
+        unauth-proxy-match
+        (match->proxy-info unauth-proxy-match)
+
+        :else
+        (binding [*out* *err*]
+          (println "WARNING: Can't parse proxy info - found:" s "- proceeding without using proxy!")
+          nil)))))
+
+(defn jvm-proxy-settings
+  []
+  (let [http-proxy  (parse-proxy-info (or (System/getenv "http_proxy")
+                                          (System/getenv "HTTP_PROXY")))
+        https-proxy (parse-proxy-info (or (System/getenv "https_proxy")
+                                          (System/getenv "HTTPS_PROXY")))]
+    (cond-> []
+      http-proxy (concat [(format "-Dhttp.proxyHost=%s" (:host http-proxy))
+                          (format "-Dhttp.proxyPort=%s" (:port http-proxy))])
+      https-proxy (concat [(format "-Dhttps.proxyHost=%s" (:host https-proxy))
+                           (format "-Dhttps.proxyPort=%s" (:port https-proxy))]))))
+
 (defn -main [& command-line-args]
   (let [windows? (windows?)
         args (loop [command-line-args (seq command-line-args)
@@ -283,13 +324,17 @@ function Get-StringHash($str) {
            downloaded-jar))
         deps-edn
         (or (:deps-file args)
-            "deps.edn")]
+            "deps.edn")
+        clj-main-cmd
+        (vec (concat [java-cmd]
+                     (jvm-proxy-settings)
+                     ["-Xms256m" "-classpath" tools-cp "clojure.main"]))]
     (when (:resolve-tags args)
       (let [f (io/file deps-edn)]
         (if (.exists f)
-          (do (shell-command [java-cmd "-Xms256m" "-classpath" tools-cp
-                              "clojure.main" "-m" "clojure.tools.deps.alpha.script.resolve-tags"
-                              (str "--deps-file=" deps-edn)])
+          (do (shell-command (into clj-main-cmd
+                                   ["-m" "clojure.tools.deps.alpha.script.resolve-tags"
+                                    (str "--deps-file=" deps-edn)]))
               (System/exit 0))
           (binding [*out* *err*]
             (println deps-edn "does not exist")
@@ -392,27 +437,26 @@ function Get-StringHash($str) {
             _ (when (and stale (not (:describe args)))
                 (when (:verbose args)
                   (println "Refreshing classpath"))
-                (shell-command (into [java-cmd "-Xms256m"
-                                      "-classpath" tools-cp
-                                      "clojure.main" "-m" "clojure.tools.deps.alpha.script.make-classpath2"
-                                      "--config-user" config-user
-                                      "--config-project" config-project
-                                      "--libs-file" (double-quote libs-file)
-                                      "--cp-file" (double-quote cp-file)
-                                      "--jvm-file" (double-quote jvm-file)
-                                      "--main-file" (double-quote main-file)]
-                                     tools-args)))
+                (shell-command (into clj-main-cmd
+                                     (concat
+                                      ["-m" "clojure.tools.deps.alpha.script.make-classpath2"
+                                       "--config-user" config-user
+                                       "--config-project" config-project
+                                       "--libs-file" (double-quote libs-file)
+                                       "--cp-file" (double-quote cp-file)
+                                       "--jvm-file" (double-quote jvm-file)
+                                       "--main-file" (double-quote main-file)]
+                                      tools-args))))
             cp
             (cond (:describe args) nil
                   (not (str/blank? (:force-cp args))) (:force-cp args)
                   :else (slurp (io/file cp-file)))]
         (cond (:pom args)
-              (shell-command [java-cmd "-Xms256m"
-                              "-classpath" tools-cp
-                              "clojure.main" "-m" "clojure.tools.deps.alpha.script.generate-manifest2"
-                              "--config-user" config-user
-                              "--config-project" config-project
-                              "--gen=pom" (str/join " " tools-args)])
+              (shell-command (into clj-main-cmd
+                                   ["-m" "clojure.tools.deps.alpha.script.generate-manifest2"
+                                    "--config-user" config-user
+                                    "--config-project" config-project
+                                    "--gen=pom" (str/join " " tools-args)]))
               (:print-classpath args)
               (println cp)
               (:describe args)
@@ -431,10 +475,9 @@ function Get-StringHash($str) {
                          [:main-aliases (str (:main-aliases args))]
                          [:all-aliases (str (:all-aliases args))]])
               (:tree args)
-              (println (str/trim (shell-command [java-cmd "-Xms256m"
-                                                 "-classpath" tools-cp
-                                                 "clojure.main" "-m" "clojure.tools.deps.alpha.script.print-tree"
-                                                 "--libs-file" libs-file]
+              (println (str/trim (shell-command (into clj-main-cmd
+                                                      ["-m" "clojure.tools.deps.alpha.script.print-tree"
+                                                       "--libs-file" libs-file])
                                                 {:to-string? true})))
               (:trace args)
               (println "Writing trace.edn")
@@ -452,8 +495,14 @@ function Get-StringHash($str) {
                     main-cache-opts (when (.exists (io/file main-file))
                                       (slurp main-file))
                     main-cache-opts (when main-cache-opts (str/split main-cache-opts #"\s"))
-                    main-args (into (vector java-cmd jvm-cache-opts (:jvm-opts args)
-                                            (str "-Dclojure.libfile=" libs-file) "-classpath" cp "clojure.main") main-cache-opts)
+                    main-args (concat [java-cmd]
+                                      (jvm-proxy-settings)
+                                      [jvm-cache-opts
+                                       (:jvm-opts args)
+                                       (str "-Dclojure.libfile=" libs-file)
+                                       "-classpath" cp
+                                       "clojure.main"]
+                                      main-cache-opts)
                     main-args (filterv some? main-args)
                     main-args (into main-args (:args args))]
                 (shell-command main-args)))))))

--- a/test/borkdude/deps_test.cljc
+++ b/test/borkdude/deps_test.cljc
@@ -20,3 +20,7 @@
        (with-out-str
          (deps/-main "-Stree"))
        "org.clojure/clojure")))
+
+(deftest jvm-proxy-settings-test
+  ;; TODO:
+  #_(is (= "..." (deps/parse-proxy-info "..."))))


### PR DESCRIPTION
This change aims to make deps.clj pick up proxy info from env variables and pass it on to the "standard" JVM options. This enables dpes.clj to work behind an (unauthenticated) proxy to pull down dependencies etc (something the bash shell script does not do currently).
