### PR TITLE
Switch to System.Net.WebClient for faster download in windows installer

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -32,7 +32,7 @@ $download_url = "https://github.com/borkdude/deps.clj/releases/download/v$latest
 $tmp_zip_file = "$tmp_dir\deps.clj.zip"
 
 Write-Output "Downloading..."
-Invoke-WebRequest -Uri $download_url -OutFile "$tmp_zip_file" 
+(New-Object System.Net.WebClient).DownloadFile($download_url,"$tmp_zip_file")
 Write-Output 'Extracting...'
 Expand-Archive -LiteralPath "$tmp_zip_file" -DestinationPath "$tmp_dir" -Force
 


### PR DESCRIPTION
On my Windows 10 VM this brings `install.ps1` duration down to about 2 seconds.
Was previously about 18 seconds.

Closes #26