### PR TITLE
Using default value PATH when missing - avoid NPE

### DIFF
--- a/deps.clj
+++ b/deps.clj
@@ -162,7 +162,7 @@ For more info, see:
     (str sw)))
 
 (defn which [executable]
-  (let [path (System/getenv "PATH")
+  (let [path (or (System/getenv "PATH") ^String "")
         paths (.split path path-separator)]
     (loop [paths paths]
       (when-first [p paths]


### PR DESCRIPTION
I did not know how to use when-let (with two bindings).