### PR TITLE
don't try to read classpath file if help flag is passed

### DIFF
--- a/deps.clj
+++ b/deps.clj
@@ -181,7 +181,7 @@ For more info, see:
  https://clojure.org/reference/repl_and_main"))
 
 (defn describe-line [[kw val]]
-  (pr kw val ))
+  (pr kw val))
 
 (defn describe [lines]
   (let [[first-line & lines] lines]
@@ -613,7 +613,7 @@ For more info, see:
             (print res) (flush))))
       (let [cp (cond (or (:describe opts)
                          (:prep opts)
-                         (:help nil)) nil
+                         (:help opts)) nil
                      (not (str/blank? (:force-cp opts))) (:force-cp opts)
                      :else (slurp (io/file cp-file)))]
         (cond (:help opts) (do (println help-text)

--- a/src/borkdude/deps.clj
+++ b/src/borkdude/deps.clj
@@ -181,7 +181,7 @@ For more info, see:
  https://clojure.org/reference/repl_and_main"))
 
 (defn describe-line [[kw val]]
-  (pr kw val ))
+  (pr kw val))
 
 (defn describe [lines]
   (let [[first-line & lines] lines]
@@ -613,7 +613,7 @@ For more info, see:
             (print res) (flush))))
       (let [cp (cond (or (:describe opts)
                          (:prep opts)
-                         (:help nil)) nil
+                         (:help opts)) nil
                      (not (str/blank? (:force-cp opts))) (:force-cp opts)
                      :else (slurp (io/file cp-file)))]
         (cond (:help opts) (do (println help-text)


### PR DESCRIPTION
**Summary**
If the help flag is passed, we won't actually use the value of the classpath, so we don't need to read the classpath file.

**Why**
- It looks like this was the desired behavior, but there was maybe a typo??? that led to `(:help nil)`.
- The existing behavior was causing an error (at least on Windows) when running `deps -h` in a directory that a) has a deps.edn file, and b) has not been "prepped" (doesn't have a `.cpcache/xyz.cp` file)

```shell
# starting from an empty directory
C:\sandbox>deps -h
(help text prints...)

C:\sandbox>echo {} > deps.edn

C:\sandbox>deps -h
Exception in thread "main" java.io.FileNotFoundException: .cpcache\CF5269FA8A90A7E015FB52BECFC2DD5E.cp (The system cannot find the path specified)
...
```