### PR TITLE
don't try to read classpath file when version flag is passed

### DIFF
--- a/src/borkdude/deps.clj
+++ b/src/borkdude/deps.clj
@@ -641,7 +641,8 @@ For more info, see:
             (print res) (flush))))
       (let [cp (cond (or (:describe opts)
                          (:prep opts)
-                         (:help opts)) nil
+                         (:help opts)
+                         (:version opts)) nil
                      (not (str/blank? (:force-cp opts))) (:force-cp opts)
                      :else (slurp (io/file cp-file)))]
         (cond (:help opts) (do (println @help-text)


### PR DESCRIPTION
fixes babashka/babashka#1071

similar to #49 - when the version flag is passed, we don't run make-classpath, so if the classpath file isn't there, then slurping it will cause an error. But, since we're just doing the version print out, we don't need to slurp the classpath file.