### PR TITLE
consolidate check for parameters that make classpath file unnecessary (and some changes for windows testing)

### DIFF
--- a/script/babashka_test.bat
+++ b/script/babashka_test.bat
@@ -1,0 +1,5 @@
+set DEPS_CLJ_TEST_ENV=babashka
+
+bb -cp "src;test;resources" ^
+   -e "(require '[clojure.test :as t] '[borkdude.deps-test])" ^
+   -e "(let [{:keys [:fail :error]} (t/run-tests 'borkdude.deps-test)] (System/exit (+ fail error)))"

--- a/script/exe_test.bat
+++ b/script/exe_test.bat
@@ -1,0 +1,3 @@
+set DEPS_CLJ_TEST_ENV=native
+
+.\deps -M:test

--- a/src/borkdude/deps.clj
+++ b/src/borkdude/deps.clj
@@ -617,11 +617,10 @@ For more info, see:
               (:trace opts)
               (conj "--trace")
               tree?
-              (conj "--tree")))]
+              (conj "--tree")))
+          classpath-not-needed? (boolean (some #(% opts) [:describe :help :version]))]
       ;;  If stale, run make-classpath to refresh cached classpath
-      (when (and stale (not (or (:describe opts)
-                                (:help opts)
-                                (:version opts))))
+      (when (and stale (not classpath-not-needed?))
         (when (:verbose opts)
           (warn "Refreshing classpath"))
         (let [res (shell-command (into clj-main-cmd
@@ -639,10 +638,8 @@ For more info, see:
                                  {:to-string? tree?})]
           (when tree?
             (print res) (flush))))
-      (let [cp (cond (or (:describe opts)
-                         (:prep opts)
-                         (:help opts)
-                         (:version opts)) nil
+      (let [cp (cond (or classpath-not-needed? 
+                         (:prep opts)) nil
                      (not (str/blank? (:force-cp opts))) (:force-cp opts)
                      :else (slurp (io/file cp-file)))]
         (cond (:help opts) (do (println @help-text)

--- a/test/borkdude/deps_test.clj
+++ b/test/borkdude/deps_test.clj
@@ -116,6 +116,7 @@
       (try
         (let [{:keys [out exit]}
               ; use bogus deps-file to force using CLJ_CONFIG instead of current directory,
+              ; meaning that the cache directory will be empty
               (-> (process (str invoke-deps-cmd "-Sdeps-file force_clj_config/missing.edn " option)
                     {:out :string
                      :err :string


### PR DESCRIPTION
### Source changes
borkdude commented on https://github.com/borkdude/deps.clj/pull/52:
> can we maybe restructure the code a bit so if we add more options, we don't forget to add that option in this list?

So, the actual app code change is just consolidating the check for the options that make the classpath cache file not necessary (currently describe, help, and version) into one place.

### Test changes
I end up doing a lot of dev on Windows, so I wanted to make some test facilities available. I'm open to taking them out, but I'm sort of assuming that more testability wouldn't be viewed as a bad thing.

#### babashka_test.bat, exe_test.bat
These are just cmd equivalents to the corresponding shell scripts

#### deps_test.clj
- whitespace-test and jvm-opts-test - skip these tests on Windows (for now) to avoid shell escaping differences
- in order for multiple tests to choose the 'base' deps command based on the DEPS_CLJ_TEST_ENV environment variable, the case logic gets pulled out to its own var
- add a test for "classpath not necessary" options to check that no classpath file is created, and that the absence of a classpath file doesn't cause any non-zero exit codes (basically a test that would reproduce the issues fixed by #52 and #49 )

### Next steps
A thing I'd like to consider (if these changes are acceptable) is possibly running the executable tests in the Windows CI. But let me know if I'm overdoing it. 😄 