### PR TITLE
Add support for new ClojureTools CLJ_JVM_OPTS and JAVA_OPTS env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,13 +296,13 @@ $ lein run -m borkdude.deps -Spath
 To run jvm tests:
 
 ```
-$ script/jvm_test
+$ bb test
 ```
 
 To run with babashka after making changes to `src/borkdude/deps.clj`, you should run:
 
 ```
-$ script/gen_script.clj
+$ bb gen-script
 ```
 
 and then:

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,18 @@
+{:paths ["resources"]
+
+ :tasks
+ {:requires [[babashka.deps :as deps]
+             [babashka.process :as p]]
+
+  gen-script {:doc "Regen `./deps[.clj|.bat]` from `src/borkdude/deps.clj`."
+              :task (let [script "script/gen_symclj"
+                          bb (str \" (.get (.command (.info (java.lang.ProcessHandle/current)))) \")]
+                      (p/shell bb "script/gen_script.clj"))}
+
+  test {:doc "Run all tests."
+        :task
+        (doseq [args '[[-M:test] [-M -m borkdude.deps -M:test]]]
+          (println :testing... 'clojure args)
+          (-> (deps/clojure args)
+              p/check)
+          (println))}}}

--- a/bb.edn
+++ b/bb.edn
@@ -5,9 +5,7 @@
              [babashka.process :as p]]
 
   gen-script {:doc "Regen `./deps[.clj|.bat]` from `src/borkdude/deps.clj`."
-              :task (let [script "script/gen_symclj"
-                          bb (str \" (.get (.command (.info (java.lang.ProcessHandle/current)))) \")]
-                      (p/shell bb "script/gen_script.clj"))}
+              :task (load-file "script/gen_script.clj")}
 
   test {:doc "Run all tests."
         :task

--- a/src/borkdude/deps.clj
+++ b/src/borkdude/deps.clj
@@ -193,7 +193,7 @@ For more info, see:
       (print "\n ") (describe-line line))
     (println "}")))
 
-(def ^:private ^:dynamic *getenv-fn*
+(def ^:private ^:dynamic ^String *getenv-fn*
   "Get ENV'ironment variable."
   (fn [env] (java.lang.System/getenv env)))
 


### PR DESCRIPTION
Hi,

could you please consider patch to support two new ClojureTools env variables as per #58.

I have created a a test to capture  the arguments passed to the `shell-command` which invokes `java`, so as to confirm the right env values are picked for the different invocation types:

1. The `CLJ_JVM_OPTS` are passed to the java exec when preparing deps (`-P` and `-Spom`)
2. The `JAVA_OPTS` are passed to the java exec at all other times.

ref: https://github.com/clojure/brew-install/commit/7914954030ca21f7b928b6f064ace086efdc9057

The `get-shell-command-args` macro will rebind the `shell-command` fn so as to capture the args. I have also created a new `*getenv-fn` so as to be able to add env variables during testing.

I have noticed there is no equivalent `script/jvm_test` for MS-Windows available, so I went ahead and created a `bb.edn` file to do the same as a task. I hope you don't mind. I am even thinking it will be a good idea to move all these script under `bb.edn` in a follow up PR?

Thanks,