### PR TITLE
CI: run jvm and bb tests on jdk1.8/11/17 across all archs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
       - run:
           name: Run JVM tests
           command: |
+            java -version
             bb jvm-test
       - run:
           name: Run babashka tests
@@ -88,6 +89,7 @@ jobs:
       - run:
           name: Run JVM tests
           command: |
+            java -version
             bb jvm-test
       - run:
           name: Run babashka tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,19 @@
 # Check https://circleci.com/docs/2.0/language-clojure/ for more details
 #
 version: 2.1
+
 jobs:
-  jvm:
+  linux-test-and-uberjar:
+    # Run jvm and babashka tests on linux on the given JDK version,
+    # and also build uberjar on the same version when the UBERJAR-JDK
+    # matches the JDK version.
+    parameters:
+      jdk:
+        type: string
+      uberjar-jdk:
+        type: string
     docker:
-      # specify the version you desire here
-      - image: circleci/clojure:lein-2.8.1
-    working_directory: ~/repo
+      - image: cimg/clojure:1.10.3-<<parameters.jdk>>
     environment:
       LEIN_ROOT: "true"
     steps:
@@ -25,7 +32,7 @@ jobs:
             chmod +x linux-install-1.10.3.998.sh
             sudo ./linux-install-1.10.3.998.sh
       - run:
-          name: Install babashka
+          name: Install latest babashka
           command: |
             bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir ~
             sudo mv ~/bb /usr/local/bin/bb
@@ -33,39 +40,6 @@ jobs:
           name: Run JVM tests
           command: |
             bb jvm-test
-      - save_cache:
-          paths:
-            - ~/.m2
-          key: v1-dependencies-{{ checksum "deps.edn" }}
-      - run:
-          name: Create uberjar
-          command: |
-            mkdir -p /tmp/release
-            lein do clean, uberjar
-            VERSION=$(cat resources/DEPS_CLJ_VERSION)
-            cp target/deps.clj-$VERSION-standalone.jar /tmp/release
-      - store_artifacts:
-          path: /tmp/release
-          destination: release
-  babashka:
-    docker:
-      # specify the version you desire here
-      - image: circleci/clojure:lein-2.8.1
-    working_directory: ~/repo
-    environment:
-      LEIN_ROOT: "true"
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "deps.edn" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-      - run:
-          name: Install babashka
-          command: |
-            bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir ~
-            sudo mv ~/bb /usr/local/bin/bb
       - run:
           name: Run babashka tests
           command: |
@@ -74,7 +48,55 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "deps.edn" }}
-  linux:
+      - when:
+          condition:
+            equal: [ <<parameters.uberjar-jdk>>, <<parameters.jdk>> ]
+          steps:
+            - run:
+                name: Create uberjar
+                command: |
+                  mkdir -p /tmp/release
+                  lein do clean, uberjar
+                  VERSION=$(cat resources/DEPS_CLJ_VERSION)
+                  cp target/deps.clj-$VERSION-standalone.jar /tmp/release
+            - store_artifacts:
+                path: /tmp/release
+                destination: release
+
+  mac-test:
+    # Run jvm and babsashka tests on the given JDK version.
+    parameters:
+      jdk:
+        type: string
+    macos:
+      xcode: 14.0.0
+    steps:
+      - checkout
+      - run:
+          name: Install <<parameters.jdk>>
+          command: |
+            brew install <<parameters.jdk>>
+
+      - run:
+          name: Install Clojure
+          command: |
+            brew install clojure/tools/clojure
+      - run:
+          name: Install babashka
+          command: |
+            bash <(curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install) --dir ~
+            sudo mv ~/bb /usr/local/bin/bb
+      - run:
+          name: Run JVM tests
+          command: |
+            bb jvm-test
+      - run:
+          name: Run babashka tests
+          command: |
+            bb babashka-test
+
+  linux-native:
+    # Build native exec release on Linux.
     docker:
       - image: circleci/clojure:lein-2.8.1
     working_directory: ~/repo
@@ -138,7 +160,8 @@ jobs:
       - store_artifacts:
           path: /tmp/release
           destination: release
-  mac:
+  mac-native:
+    # Build native executable release on macos.
     macos:
       xcode: "14.0.0"
     environment:
@@ -226,19 +249,26 @@ workflows:
   version: 2
   ci:
     jobs:
-      - jvm
-      - babashka
-      - linux
-      - mac
+      - linux-test-and-uberjar:
+          matrix:
+            parameters:
+              jdk: ["openjdk-8.0", "openjdk-11.0", "openjdk-17.0"]
+              uberjar-jdk: ["openjdk-8.0"]
+      - mac-test:
+          matrix:
+            parameters:
+              jdk: ["openjdk@8", "openjdk@11", "openjdk@17"]
+      - linux-native
+      - mac-native
       - deploy:
           filters:
             branches:
               only: master
           requires:
-            - jvm
-            - babashka
-            - linux
-            - mac
+            - linux-test-and-uberjar
+            - mac-test
+            - linux-native
+            - mac-native
       # - docker:
       #     filters:
       #       branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,11 @@ jobs:
       - run:
           name: Install <<parameters.jdk>>
           command: |
-            brew install <<parameters.jdk>>
-
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install <<parameters.jdk>>
       - run:
           name: Install Clojure
           command: |
-            brew install clojure/tools/clojure
+            .circleci/script/install-clojure /usr/local
       - run:
           name: Install babashka
           command: |

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ $ lein run -m borkdude.deps -Spath
 To run jvm tests:
 
 ```
-$ bb test
+$ bb jvm-test
 ```
 
 To run with babashka after making changes to `src/borkdude/deps.clj`, you should run:
@@ -328,7 +328,7 @@ The script also assumes that you have
 Run the compile script with:
 
 ```
-$ script/compile
+$ bb compile
 ```
 
 If everything worked out, there will be a `deps` binary in the root of the
@@ -337,7 +337,7 @@ project.
 To run executable tests:
 
 ```
-$ script/exe_test
+$ bb exe-test
 ```
 
 ## License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,8 @@ for:
         
         SET PATH=%JAVA_HOME%\bin;%PATH%
 
+        java -version
+        
         bb jvm-test
 
         bb babashka-test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,44 +9,86 @@ clone_folder: C:\projects\deps.clj
 environment:
   GRAALVM_HOME: C:\projects\deps.clj\graalvm\graalvm-ce-java11-20.3.0
 
+  matrix:
+    - JDK: 1.8
+      grp: test
+      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    - JDK: 11
+      grp: test
+      JAVA_HOME: C:\Program Files\Java\jdk11
+    - JDK: 17
+      grp: test
+      JAVA_HOME: C:\Program Files\Java\jdk17
+    - JDK: GraalVM      
+
 cache:
   - C:\ProgramData\chocolatey\lib -> project.clj, appveyor.yml
   - '%USERPROFILE%\.m2 -> project.clj'
   - 'graalvm -> appveyor.yml'
+  - '%USERPROFILE%\Documents\WindowsPowerShell\Modules -> appveyor.yml'
 
-build_script:
-- cmd: >-
-    powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein.bat', 'lein.bat')"
+install:
+  - cmd: >-
+      powershell -Command "if (Test-Path('bb.exe')) { return } else { (New-Object Net.WebClient).DownloadFile('https://github.com/babashka/babashka/releases/download/v0.9.162/babashka-0.9.162-windows-amd64.zip', 'bb.zip') }"
 
-    call lein self-install
+      powershell -Command "if (Test-Path('bb.exe')) { return } else { Expand-Archive bb.zip . }"
 
-- cmd: >-
-    powershell -Command "if (Test-Path('bb.exe')) { return } else { (New-Object Net.WebClient).DownloadFile('https://github.com/babashka/babashka/releases/download/v0.9.162/babashka-0.9.162-windows-amd64.zip', 'bb.zip') }"
+for:
+  -
+    matrix:
+      only:
+        - grp: test
 
-    powershell -Command "if (Test-Path('bb.exe')) { return } else { Expand-Archive bb.zip . }"
+    build_script:
+    - ps: >-
+        if (Test-Path("$Env:USERPROFILE\Documents\WindowsPowerShell\Modules\ClojureTools"))
+        { return }
+        else
+        { echo "1" | powershell -noprofile -command "Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://download.clojure.org/install/win-install-1.11.1.1165.ps1')" }
 
-- cmd: >-
-    call lein do clean, uberjar
+    test_script:
+    - cmd: >-
+        echo :JAVA_HOME %JAVA_HOME%
+        
+        SET PATH=%JAVA_HOME%\bin;%PATH%
 
-    set /P DEPS_CLJ_VERSION=< resources\DEPS_CLJ_VERSION
+        bb jvm-test
 
-    call java -jar "target/deps.clj-%DEPS_CLJ_VERSION%-standalone.jar" "-Sverbose" "-Spath"
+        bb babashka-test
+        
+  -
+    matrix:
+      only:
+        - JDK: GraalVM
+            
+    build_script:
+    - cmd: >-
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein.bat', 'lein.bat')"
 
-- cmd: >-
-    call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+        call lein self-install
 
-    powershell -Command "if (Test-Path('graalvm')) { return } else { (New-Object Net.WebClient).DownloadFile('https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.0/graalvm-ce-java11-windows-amd64-20.3.0.zip', 'graalvm.zip') }"
+    - cmd: >-
+        call lein do clean, uberjar
 
-    powershell -Command "if (Test-Path('graalvm')) { return } else { Expand-Archive graalvm.zip graalvm }"
+        set /P DEPS_CLJ_VERSION=< resources\DEPS_CLJ_VERSION
 
-    %GRAALVM_HOME%\bin\gu.cmd install native-image
+        call java -jar "target/deps.clj-%DEPS_CLJ_VERSION%-standalone.jar" "-Sverbose" "-Spath"
 
-    bb compile
+    - cmd: >-
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 
-test_script:
-- cmd: >-
-    bb exe-test
-    
-artifacts:
-- path: deps.clj-*-windows-amd64.zip
-  name: deps.exe
+        powershell -Command "if (Test-Path('graalvm')) { return } else { (New-Object Net.WebClient).DownloadFile('https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.0/graalvm-ce-java11-windows-amd64-20.3.0.zip', 'graalvm.zip') }"
+
+        powershell -Command "if (Test-Path('graalvm')) { return } else { Expand-Archive graalvm.zip graalvm }"
+
+        %GRAALVM_HOME%\bin\gu.cmd install native-image
+
+        bb compile
+
+    test_script:
+    - cmd: >-
+        bb exe-test
+
+    artifacts:
+      - path: deps.clj-*-windows-amd64.zip
+        name: deps.exe


### PR DESCRIPTION
Hi @borkdude,

could you please consider patch to introduce matrices in the `appveyor` and `circleci` configuration files for running the jvm and babashka tests across `[jdk 1.8, 11, 17]`x`[macos, ubuntu, windows]`. This is part of #61 

The config commands for building the GraalVM image on appveyor and circleci should be **exactly** the same as before. 

I discovered how to use matrices in `circleci`, so I did not consider writing a bb script to create the configuration for doing the same programmatically, as you've suggested. This would have incured extra work and introducing an additional level of indirection without any functional benefit. Let me know though what you think, happy to make amends.

I took the liberty to switch the jvm-test/uberjar job from the legacy unsupported `circleci/clojure:lein-2.8.1` image to the new generation `img/clojure:1.10.3` image. The main reason was that it is trivial to specify the jdk versio to use.

The uberjar is only build on jdk1.8. I've double checked and this is the jdk version used by the old image:

```
openjdk version "1.8.0_181"
OpenJDK Runtime Environment (build 1.8.0_181-8u181-b13-2~deb9u1-b13)
OpenJDK 64-Bit Server VM (build 25.181-b13, mixed mode)
```

I've also renamed the circle jobs to reflect their responsibilities better.

The CI runs have now become much slower due to the extending testing. If you think this to be an issue/annoyance we could perhaps reduce the time by pruning some jdk tests. We can run just JDK8 test on macos (since macos behavior is likely to be more similar to ubuntu tests and thus covered by it), and can remove `jdk11` run from windows runs (we know there is a difference in jdk17, thus we cover at least two versions, jdk8 and jdk17).

I have also did minor updates to `README.md` to reflect the move to bb tasks from the previous check in.

Thanks,