### PR TITLE
GH action to run all jvm & bb tests on [mac,ubuntu,win]x[jdk8,11,17]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test-and-maybe-uberjar:
+    # Runs the JVM and babashka tests across all OSs and JDKs, and
+    # creates an uberjar when the OS and JDK matches the UBERJAR_OS
+    # and UBERJAR_JDK env variables respectively.
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        jdk: [8, 11, 17]
+    env:
+      UBERJAR_OS: 'ubuntu'
+      UBERJAR_JDK: 8
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare java ${{ matrix.jdk }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.jdk }}
+
+      - name: Install Clojure
+        uses: DeLaGuardo/setup-clojure@9.5
+        with:
+          bb: '0.10.163'
+          cli: '1.10.3.1013'
+          lein: '2.9.10'
+
+      - name: Cache clojure dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn', 'project.clj') }}
+          restore-keys: cljdeps-
+
+      - name: Run JVM tests
+        run: bb jvm-test
+
+      - name: Run babashka tests
+        run: bb babashka-test
+
+      - name: Create ubejar
+        if: "startsWith (matrix.os, env.UBERJAR_OS) && env.UBERJAR_JDK == matrix.jdk"
+        run: |
+          mkdir -p /tmp/release
+          lein do clean, uberjar
+          VERSION=$(cat resources/DEPS_CLJ_VERSION)
+          cp target/deps.clj-$VERSION-standalone.jar /tmp/release
+
+      - name: Upload artifacts
+        if: "startsWith (matrix.os, env.UBERJAR_OS) && env.UBERJAR_JDK == matrix.jdk"
+        uses: actions/upload-artifact@v2
+        with:
+          name: release
+          path: /tmp/release/
+          if-no-files-found: error


### PR DESCRIPTION
Hi @borkdude,

as discussed in #64, here is an alternative option to run the jvm and bb tests on GH. This is part of #61.

A simple GH action has been created that demonstrate the power of GH using `setup-java`, DeLaGuardo's excellent `setup-clojure` and `bb` working in tandem to seamlessly achieve running jobs across all three macos, ubuntu and windows architectures.

It turned out that the special arg passing case I've introduced for the `main-opts` test earlier was a fluke of my JDK-17 installation, and does not occur in reality, so I've reverted the change (and this proves the point how great it is of having tests across all architectures/JDKs).

I have also introduced a form at the top of the `borkdude.deps-test` namespace to printout the actual path and version of the `java` program `deps.clj` will use to invoke java internally, useful for a user to validate the actual version used in the tests, as was raised in the previous PR.

The job will also build an `uberjar` on ubuntu/jdk1.8, but I am not sure where and what needs to change to pick this release jar instead of the one in `circleci`. Ideally I would have liked to remove all jvm/babashka tests and uberjar creation from circleci and only leave graalvm images creation jobs done elsewhere.

The whole job matrix takes ~4.30min to run, which is in my opinion exceptional (until it lasts of course :)).

Please let me know of your thoughts.

Thanks,