### PR TITLE
Separate out proxy handling code to facilitate embedding

### DIFF
--- a/src/borkdude/deps.clj
+++ b/src/borkdude/deps.clj
@@ -488,8 +488,8 @@ public class ClojureToolsDownloader {
   {"-J" :jvm-opts
    "-R" :resolve-aliases
    "-C" :classpath-aliases
-   "-A" :repl-aliases})
-
+   "-A" :repl-aliases
+   })
 
 (def bool-opts->keyword
   {"-Spath" :print-classpath

--- a/test/borkdude/deps_test.clj
+++ b/test/borkdude/deps_test.clj
@@ -121,7 +121,25 @@
   (is (= {:host "aHost" :port "1234"} (deps/parse-proxy-info "http://user:pw@aHost:1234")))
   (is (= {:host "aHost" :port "1234"} (deps/parse-proxy-info "https://aHost:1234")))
   (is (= {:host "aHost" :port "1234"} (deps/parse-proxy-info "https://user:pw@aHost:1234")))
-  (is (nil? (deps/parse-proxy-info "http://aHost:abc"))))
+  (is (nil? (deps/parse-proxy-info "http://aHost:abc")))
+  (is (= {:http-proxy {:host "aHost" :port "1234"}}
+         (binding [deps/*getenv-fn* {"http_proxy" "http://aHost:1234"}]
+           (deps/env-proxy-info))))
+  (is (= {:http-proxy {:host "aHost" :port "1234"}}
+         (binding [deps/*getenv-fn* {"HTTP_PROXY" "http://aHost:1234"}]
+           (deps/env-proxy-info))))
+  (is (= {:https-proxy {:host "aHost" :port "1234"}}
+         (binding [deps/*getenv-fn* {"https_proxy" "http://aHost:1234"}]
+           (deps/env-proxy-info))))
+  (is (= {:https-proxy {:host "aHost" :port "1234"}}
+         (binding [deps/*getenv-fn* {"HTTPS_PROXY" "http://aHost:1234"}]
+           (deps/env-proxy-info))))
+  (is (= {}
+         (binding [deps/*getenv-fn* {}]
+           (deps/env-proxy-info))))
+  (is (= {}
+         (binding [deps/*getenv-fn* {"http_proxy" "http://aHost:abc"}]
+           (deps/env-proxy-info)))))
 
 (deftest jvm-opts-test
   (let [temp-dir (fs/create-temp-dir)
@@ -383,7 +401,7 @@
   (let [deps-map (pr-str '{:mvn/local-repo "test/mvn" :deps {medley/medley {:mvn/version "1.4.0"}
                                                              io.github.borkdude/quickblog {:git/sha "8f5898ee911101a96295f59bb5ffc7517757bc8f"}}})
         delete #(do (fs/delete-tree (fs/file "test" "mvn"))
-                    (fs/delete-tree (fs/file (or (some-> (System/getenv "GITLIBS") (fs/file ))
+                    (fs/delete-tree (fs/file (or (some-> (System/getenv "GITLIBS") (fs/file))
                                                  (fs/file (System/getProperty "user.dir" ".gitlibs")))
                                              "libs" "io.github.borkdude/quickblog" "8f5898ee911101a96295f59bb5ffc7517757bc8f")))
         test #(deps/-main "-Sdeps" deps-map "-M" "-e" "(require '[medley.core]) (require '[quickblog.api])")]

--- a/test/borkdude/deps_test.clj
+++ b/test/borkdude/deps_test.clj
@@ -401,7 +401,7 @@
   (let [deps-map (pr-str '{:mvn/local-repo "test/mvn" :deps {medley/medley {:mvn/version "1.4.0"}
                                                              io.github.borkdude/quickblog {:git/sha "8f5898ee911101a96295f59bb5ffc7517757bc8f"}}})
         delete #(do (fs/delete-tree (fs/file "test" "mvn"))
-                    (fs/delete-tree (fs/file (or (some-> (System/getenv "GITLIBS") (fs/file))
+                    (fs/delete-tree (fs/file (or (some-> (System/getenv "GITLIBS") (fs/file ))
                                                  (fs/file (System/getProperty "user.dir" ".gitlibs")))
                                              "libs" "io.github.borkdude/quickblog" "8f5898ee911101a96295f59bb5ffc7517757bc8f")))
         test #(deps/-main "-Sdeps" deps-map "-M" "-e" "(require '[medley.core]) (require '[quickblog.api])")]


### PR DESCRIPTION
Fixes https://github.com/borkdude/deps.clj/issues/89.

Separates out the three parts of proxy env var handling: parsing the env vars, setting the JVM properties in the current process, and calculating the JVM args to pass to new processes. I had to move some code higher up in the file to allow it to be called from `clojure-tools-download-direct`.

I haven't added this to the changelog since it's not user visible, but if you'd like me to add it I can do that.

I added tests for the proxy parsing part, and manually checked the other parts using the debugger - they're hard to test automatically.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/borkdude/deps.clj/blob/master/CHANGELOG.md) file with a description of the addressed issue.
