### PR TITLE
Merge "Projects using deps.clj" sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ a programmatic API under `babashka.deps`.
 
 Used to provide a getting started REPL.
 
+### [Cursive](https://cursive-ide.com/)
+
+The deps integration uses deps.clj since version 1.13.0.
+
 ## Status
 
 Deps.clj tries to follow the official Clojure CLI as faithfully as possible and
@@ -448,10 +452,6 @@ To run executable tests:
 ```
 $ bb exe-test
 ```
-
-## Projects using deps.clj
-
-- [Cursive](https://groups.google.com/g/cursive/c/9dTn12AkHzA/m/R_dj2fzRBAAJ)
 
 ## License
 


### PR DESCRIPTION
The README currently contains two "Projects using deps.clj" sections. I merged the bottom one mentioning Cursive into the top one mentioning Babashka and Calva.

Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/borkdude/deps.clj/blob/master/CHANGELOG.md) file with a description of the addressed issue.
