### PR TITLE
Align `home-dir` with original scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ DEPS_CLJ_TOOLS_VERSION=1.11.1.1165 bb clojure
 
 [deps.clj](https://github.com/borkdude/deps.clj): a faithful port of the clojure CLI bash script to Clojure
 
+## Unreleased
+
+- [#114](https://github.com/borkdude/deps.clj/issues/114): Align with original scripts on how to determine home directory
+
 ## 1.11.1.1413
 
 - Catch up with CLI `1.11.1.1413`

--- a/deps.bat
+++ b/deps.bat
@@ -269,9 +269,9 @@ For more info, see:
 
 (defn- home-dir []
   (if windows?
-    ;; workaround for https://github.com/oracle/graal/issues/1630
-    (*getenv-fn* "userprofile")
-    (System/getProperty "user.home")))
+    (or (*getenv-fn* "HOME")
+        (*getenv-fn* "USERPROFILE"))
+    (*getenv-fn* "HOME")))
 
 (def ^:private java-exe (if windows? "java.exe" "java"))
 

--- a/deps.clj
+++ b/deps.clj
@@ -264,9 +264,9 @@ For more info, see:
 
 (defn- home-dir []
   (if windows?
-    ;; workaround for https://github.com/oracle/graal/issues/1630
-    (*getenv-fn* "userprofile")
-    (System/getProperty "user.home")))
+    (or (*getenv-fn* "HOME")
+        (*getenv-fn* "USERPROFILE"))
+    (*getenv-fn* "HOME")))
 
 (def ^:private java-exe (if windows? "java.exe" "java"))
 

--- a/src/borkdude/deps.clj
+++ b/src/borkdude/deps.clj
@@ -261,9 +261,9 @@ For more info, see:
 
 (defn- home-dir []
   (if windows?
-    ;; workaround for https://github.com/oracle/graal/issues/1630
-    (*getenv-fn* "userprofile")
-    (System/getProperty "user.home")))
+    (or (*getenv-fn* "HOME")
+        (*getenv-fn* "USERPROFILE"))
+    (*getenv-fn* "HOME")))
 
 (def ^:private java-exe (if windows? "java.exe" "java"))
 


### PR DESCRIPTION
The original bash script uses the `HOME` environment variable[1] to determine the user's home directory while we were using thee `user.home` JVM property on non-windows platforms. This turns out to not be equivalent (see e.g. JDK-8280357[2] for a recent issue caused by this). So instead, we now also use the environment variable.

As it turns out, the original Powershell script also first checks the `HOME` environment variable[3] before falling back to `USERPROFILE` (which is what we were using so far), so we also align that to ensure equivalent behavior. This also means we can drop the "workaround" comment here since it no longer is one.

Closes #114.

[1]  https://github.com/clojure/brew-install/blob/b03428b1b31a8d60573a284d6971fbd3db7b748d/src/main/resources/clojure/install/clojure#L280
[2]  https://bugs.openjdk.org/browse/JDK-8280357
[3]  https://github.com/clojure/brew-install/blob/dabb82bd011b0510006dd88464f350052adb69b5/src/main/resources/clojure/install/ClojureTools.psm1#L254-L258

Please answer the following questions and leave the below in as part of your PR.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/borkdude/deps.clj/blob/master/CHANGELOG.md) file with a description of the addressed issue.
