### PR TITLE
docs: badge: no longer building on appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # deps.clj
 
 [![CircleCI](https://circleci.com/gh/borkdude/deps.clj/tree/master.svg?style=shield)](https://circleci.com/gh/borkdude/deps.clj/tree/master)
-[![Build status](https://ci.appveyor.com/api/projects/status/wwfs4utm08dd9vx2/branch/master?svg=true)](https://ci.appveyor.com/project/borkdude/deps.clj/branch/master)
+[![build-windows](https://github.com/borkdude/deps.clj/actions/workflows/build-windows.yml/badge.svg)](https://github.com/borkdude/deps.clj/actions/workflows/build-windows.yml)
 [![Clojars Project](https://img.shields.io/clojars/v/borkdude/deps.clj.svg)](https://clojars.org/borkdude/deps.clj)
 
 ## About


### PR DESCRIPTION
Happened to notice dead appveyor badge.
Switch badge to github actions "buiild-windows" action.

Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/borkdude/deps.clj/blob/master/CHANGELOG.md) file with a description of the addressed issue.
